### PR TITLE
Update manychat-dialogflow.py

### DIFF
--- a/manychat-dialogflow.py
+++ b/manychat-dialogflow.py
@@ -120,7 +120,6 @@ class ManyChat:
                     ]
                 }
             },
-            'message_tag': 'ACCOUNT_UPDATE'
         }
 
         response = requests.post(


### PR DESCRIPTION
Remove the ACCOUNT_UPDATE message_tag type to avoid problems with new Facebook restrictions.